### PR TITLE
Correção: removido texto de comentário da View de Configuração

### DIFF
--- a/Views/Configure.cshtml
+++ b/Views/Configure.cshtml
@@ -131,7 +131,6 @@
                     </div>
                 </div>
 
-                //daqui pra baixo
                 <div class="form-group">
                     <div class="col-md-3">
                         <nop-label asp-for="DeclaredMinimumValue" />


### PR DESCRIPTION
O comentário no código-fonte da View de Configuração estava sendo exibido para os usuários na tela de configuração do plugin.

![image](https://user-images.githubusercontent.com/904616/98474987-6539c400-21d4-11eb-976e-c0c4c581b05b.png)

